### PR TITLE
Adding initial interpreter to evaluate expressions

### DIFF
--- a/LexTree/Interpreter/Interpreter.cpp
+++ b/LexTree/Interpreter/Interpreter.cpp
@@ -1,0 +1,186 @@
+#include "Interpreter.h"
+#include "../LexTree.h"
+#include <iostream>
+#include <any>
+
+namespace lex
+{
+    // Convert value to string for printing
+    std::string value_to_string(const Value& value)
+    {
+        if (std::holds_alternative<std::monostate>(value))
+        {
+            return "nil";
+        }
+        else if (std::holds_alternative<bool>(value))
+        {
+            return std::get<bool>(value) ? "true" : "false";
+        }
+        else if (std::holds_alternative<double>(value))
+        {
+            std::string text = std::to_string(std::get<double>(value));
+            // Remove trailing zeros
+            if (text.find('.') != std::string::npos)
+            {
+                text = text.substr(0, text.find_last_not_of('0') + 1);
+                if (text.back() == '.') text = text.substr(0, text.size() - 1);
+            }
+            return text;
+        }
+        else if (std::holds_alternative<std::string>(value))
+        {
+            return std::get<std::string>(value);
+        }
+        return "unknown";
+    }
+
+    void Interpreter::check_number_operand(const Token& operator_token, const Value& operand)
+    {
+        if (std::holds_alternative<double>(operand))
+            return;
+        throw RuntimeError(operator_token, "Operand must be a number.");
+    }
+
+    void Interpreter::check_number_operands(const Token& operator_token, const Value& left, const Value& right)
+    {
+        if (std::holds_alternative<double>(left) && std::holds_alternative<double>(right))
+            return;
+        throw RuntimeError(operator_token, "Operands must be numbers.");
+    }
+
+    Value Interpreter::interpret(const ExprPtr& expression)
+    {
+        try
+        {
+            Value value = evaluate(expression);
+            return value;
+        }
+        catch (const RuntimeError& error)
+        {
+            LexTree::runtimeError(error);
+            return std::monostate{};
+        }
+        catch (const std::bad_any_cast& e) {
+            // This is more of an internal error, but we should still report it
+            std::cerr << "Internal error: " << e.what() << std::endl;
+            return std::monostate{};
+        }
+    }
+
+    Value Interpreter::evaluate(const ExprPtr& expression)
+    {
+        return std::any_cast<Value>(expression->accept(this));
+    }
+    std::any Interpreter::visitLiteralExpr(lex::Literal *expr)
+    {
+        if (std::holds_alternative<std::monostate>(expr->value))
+            return Value(std::monostate{});
+        else if (std::holds_alternative<double>(expr->value))
+            return Value(std::get<double>(expr->value));
+        else if (std::holds_alternative<std::string>(expr->value))
+            return Value(std::get<std::string>(expr->value));
+        else if (std::holds_alternative<bool>(expr->value))
+            return Value(std::get<bool>(expr->value));
+        return Value(std::monostate{});
+    }
+
+    std::any Interpreter::visitGroupingExpr(lex::Grouping *expr)
+    {
+        return evaluate(expr->expression);
+    }
+
+    std::any Interpreter::visitUnaryExpr(lex::Unary *expr)
+    {
+        Value right = evaluate(expr->right);
+        switch (expr->operator_token.type) {
+            case TokenType::BANG:
+                return Value(!is_truthy(right));
+            case TokenType::MINUS:
+                check_number_operand(expr->operator_token, right);
+                return Value(-std::get<double>(right));
+            default:
+                // Unreachable
+                return Value(std::monostate{});
+        }
+    }
+
+    std::any Interpreter::visitBinaryExpr(lex::Binary *expr)
+    {
+        Value left = evaluate(expr->left);
+        Value right = evaluate(expr->right);
+
+        switch (expr->operator_token.type) {
+            // Arithmetic operations
+            case TokenType::MINUS:
+                check_number_operands(expr->operator_token, left, right);
+                return Value(std::get<double>(left) - std::get<double>(right));
+            case TokenType::SLASH:
+                check_number_operands(expr->operator_token, left, right);
+                // Check for division by zero
+                if (std::get<double>(right) == 0.0) {
+                    throw RuntimeError(expr->operator_token, "Division by zero.");
+                }
+                return Value(std::get<double>(left) / std::get<double>(right));
+            case TokenType::STAR:
+                check_number_operands(expr->operator_token, left, right);
+                return Value(std::get<double>(left) * std::get<double>(right));
+            case TokenType::PLUS:
+                if (std::holds_alternative<double>(left) && std::holds_alternative<double>(right))
+                    return Value(std::get<double>(left) + std::get<double>(right));
+
+                if (std::holds_alternative<std::string>(left) && std::holds_alternative<std::string>(right))
+                    return Value(std::get<std::string>(left) + std::get<std::string>(right));
+
+                // Allow string concatenation with other types
+                if (std::holds_alternative<std::string>(left))
+                    return Value(std::get<std::string>(left) + value_to_string(right));
+
+                if (std::holds_alternative<std::string>(right))
+                    return Value(value_to_string(left) + std::get<std::string>(right));
+
+                throw RuntimeError(expr->operator_token,
+                                   "Operands must be two numbers or two strings.");
+                // Comparison operations
+            case TokenType::GREATER:
+                check_number_operands(expr->operator_token, left, right);
+                return Value(std::get<double>(left) > std::get<double>(right));
+            case TokenType::GREATER_EQUAL:
+                check_number_operands(expr->operator_token, left, right);
+                return Value(std::get<double>(left) >= std::get<double>(right));
+            case TokenType::LESS:
+                check_number_operands(expr->operator_token, left, right);
+                return Value(std::get<double>(left) < std::get<double>(right));
+            case TokenType::LESS_EQUAL:
+                check_number_operands(expr->operator_token, left, right);
+                return Value(std::get<double>(left) <= std::get<double>(right));
+
+                // Equality operations
+            case TokenType::BANG_EQUAL:
+                return Value(!values_equal(left, right));
+            case TokenType::EQUAL_EQUAL:
+                return Value(values_equal(left, right));
+
+            case TokenType::COMMA:
+                // Comma operator returns the value of the right-hand operand
+                return Value(right);
+
+            default:
+                // Unreachable
+                return Value(std::monostate{});
+        }
+    }
+
+    std::any Interpreter::visitTernaryExpr(Ternary* expr)
+    {
+        Value condition = evaluate(expr->condition);
+        if (is_truthy(condition))
+            return evaluate(expr->then_branch);
+        return evaluate(expr->else_branch);
+    }
+
+    std::any Interpreter::visitVariableExpr(Variable* expr)
+    {
+        // We'll implement this when we add variables and environment
+        throw RuntimeError(expr->name, "Variables not yet implemented.");
+    }
+}

--- a/LexTree/Interpreter/Interpreter.h
+++ b/LexTree/Interpreter/Interpreter.h
@@ -1,0 +1,36 @@
+#pragma once
+#include "../Parser/Expr.h"
+#include "Value.h"
+#include <stdexcept>
+
+namespace lex
+{
+    class RuntimeError: public std::runtime_error
+    {
+    public:
+        const Token token;
+
+        RuntimeError(const Token& token, const std::string& message)
+                : std::runtime_error(message), token(token) {}
+    };
+
+    class Interpreter : public ExprVisitor
+    {
+    public:
+        Value interpret(const ExprPtr& expression);
+
+        // Visit methods from ExprVisitor
+        std::any visitBinaryExpr(Binary* expr) override;
+        std::any visitGroupingExpr(Grouping* expr) override;
+        std::any visitLiteralExpr(Literal* expr) override;
+        std::any visitUnaryExpr(Unary* expr) override;
+        std::any visitTernaryExpr(Ternary* expr) override;
+        std::any visitVariableExpr(Variable* expr) override;
+
+    private:
+        // Helper methods for evaluation
+        Value evaluate(const ExprPtr& expr);
+        void check_number_operand(const Token& operator_token, const Value& operand);
+        void check_number_operands(const Token& operator_token, const Value& left, const Value& right);
+    };
+}

--- a/LexTree/Interpreter/README.md
+++ b/LexTree/Interpreter/README.md
@@ -1,0 +1,257 @@
+# Lex Interpreter Design
+
+> This document is AI written for ya'll
+
+The Lex interpreter is the component of our language implementation that evaluates the Abstract Syntax Tree (AST) and produces runtime values. This document explains the design choices, implementation details, and execution flow of the interpreter.
+
+## Table of Contents
+
+1. [Design Overview](#design-overview)
+2. [Value Representation](#value-representation)
+3. [Visitor Pattern Implementation](#visitor-pattern-implementation)
+4. [Expression Evaluation](#expression-evaluation)
+5. [Error Handling](#error-handling)
+6. [Example: Evaluating an Expression](#example-evaluating-an-expression)
+
+## Design Overview
+
+The interpreter follows a tree-walk approach, where it traverses the AST and evaluates each node according to its type. This design offers several advantages:
+
+- **Simplicity**: The implementation is straightforward and closely follows the language grammar.
+- **Flexibility**: It's easy to add new features and language constructs.
+- **Debuggability**: The execution process is transparent and easy to trace.
+
+While tree-walking interpreters are not the most performant approach (compared to bytecode VMs or JIT compilers), they are ideal for educational purposes and for languages where development speed is prioritized over execution speed.
+
+## Value Representation
+
+In C++, we need a way to represent values of different types that can be determined at runtime. We use `std::variant` for this purpose:
+
+```cpp
+// Runtime value representation
+using Value = std::variant<
+    std::monostate,  // nil
+    bool,            // boolean
+    double,          // number
+    std::string      // string
+>;
+```
+
+This approach offers several benefits:
+
+1. **Type Safety**: `std::variant` provides type-safe access to its contents.
+2. **Performance**: It's more efficient than dynamic allocation since the value is stored inline.
+3. **Pattern Matching**: We can use `std::visit` or `std::holds_alternative` for type checking.
+
+Helper functions like `is_truthy` and `values_equal` simplify common operations on these values.
+
+## Visitor Pattern Implementation
+
+The interpreter uses the Visitor pattern to traverse and evaluate the AST. This pattern separates the algorithm (evaluation) from the object structure (AST nodes).
+
+### How the Visitor Pattern Works
+
+1. Each expression class in the AST implements an `accept` method.
+2. The `accept` method calls the appropriate `visit` method on the visitor.
+3. The interpreter class implements the visitor interface.
+
+This creates a double dispatch mechanism where the execution depends on both the expression type and the visitor type.
+
+```cpp
+// Base Expression class
+class Expr {
+public:
+    virtual ~Expr() = default;
+    virtual std::any accept(ExprVisitor* visitor) = 0;
+};
+
+// Concrete expression class
+class Binary : public Expr {
+public:
+    // ...
+    std::any accept(ExprVisitor* visitor) override {
+        return visitor->visitBinaryExpr(this);
+    }
+    // ...
+};
+
+// Interpreter visitor
+class Interpreter : public ExprVisitor {
+public:
+    // ...
+    std::any visitBinaryExpr(Binary* expr) override {
+        // Evaluation logic for binary expressions
+    }
+    // ...
+};
+```
+
+### Post-Order Traversal
+
+The interpreter performs a post-order traversal of the AST, meaning it evaluates child nodes before their parents. This is essential for expressions where the result depends on evaluating sub-expressions first.
+
+For example, in a binary expression like `a + b`, we first evaluate `a`, then `b`, and finally perform the addition.
+
+## Expression Evaluation
+
+The core of the interpreter is its expression evaluation logic. Here's how each expression type is handled:
+
+### Literals
+
+Literal expressions (numbers, strings, booleans, nil) simply return their value.
+
+```cpp
+std::any Interpreter::visitLiteralExpr(Literal* expr) {
+    return Value(expr->value);
+}
+```
+
+### Grouping Expressions
+
+Grouping expressions evaluate their inner expression.
+
+```cpp
+std::any Interpreter::visitGroupingExpr(Grouping* expr) {
+    return evaluate(expr->expression);
+}
+```
+
+### Unary Expressions
+
+Unary expressions evaluate their operand and then apply the operator.
+
+```cpp
+std::any Interpreter::visitUnaryExpr(Unary* expr) {
+    Value right = evaluate(expr->right);
+
+    switch (expr->operator_token.type) {
+        case TokenType::BANG:
+            return Value(!is_truthy(right));
+        case TokenType::MINUS:
+            check_number_operand(expr->operator_token, right);
+            return Value(-std::get<double>(right));
+        // ...
+    }
+}
+```
+
+### Binary Expressions
+
+Binary expressions evaluate both operands and then apply the operator.
+
+```cpp
+std::any Interpreter::visitBinaryExpr(Binary* expr) {
+    Value left = evaluate(expr->left);
+    Value right = evaluate(expr->right);
+
+    switch (expr->operator_token.type) {
+        case TokenType::PLUS:
+            if (std::holds_alternative<double>(left) && std::holds_alternative<double>(right)) {
+                return Value(std::get<double>(left) + std::get<double>(right));
+            }
+            // String concatenation cases...
+        // Other operators...
+    }
+}
+```
+
+### Ternary Expressions
+
+Ternary expressions (condition ? then_expr : else_expr) evaluate the condition first, then either the then branch or the else branch.
+
+```cpp
+std::any Interpreter::visitTernaryExpr(Ternary* expr) {
+    Value condition = evaluate(expr->condition);
+    
+    if (is_truthy(condition)) {
+        return evaluate(expr->then_branch);
+    } else {
+        return evaluate(expr->else_branch);
+    }
+}
+```
+
+## Error Handling
+
+The interpreter includes robust error handling for runtime errors:
+
+1. **Runtime Error Class**: A custom exception class that captures both the error message and the token where the error occurred.
+2. **Type Checking**: Methods like `check_number_operand` verify operand types before operations.
+3. **Error Reporting**: The `LexTree::runtimeError` method reports errors with line numbers.
+4. **Error Recovery**: The REPL allows continued execution after errors.
+
+```cpp
+class RuntimeError : public std::runtime_error {
+public:
+    const Token token;
+    
+    RuntimeError(const Token& token, const std::string& message)
+        : std::runtime_error(message), token(token) {}
+};
+
+Value Interpreter::interpret(const ExprPtr& expression) {
+    try {
+        Value value = evaluate(expression);
+        return value;
+    } catch (const RuntimeError& error) {
+        LexTree::runtimeError(error);
+        return std::monostate{};
+    }
+}
+```
+
+## Example: Evaluating an Expression
+
+Let's trace through the evaluation of a simple expression: `5 + 3 * 4`
+
+### AST Construction
+
+The parser constructs the following AST:
+
+```
+    +
+   / \
+  5   *
+     / \
+    3   4
+```
+
+In our representation, this looks like:
+
+```
+Binary(
+  Literal(5),
+  "+",
+  Binary(
+    Literal(3),
+    "*",
+    Literal(4)
+  )
+)
+```
+
+### Evaluation Process
+
+1. Start at the root (Binary `+` expression)
+2. Evaluate the left operand: Literal `5` → 5
+3. Evaluate the right operand (Binary `*` expression)
+   a. Evaluate the left operand: Literal `3` → 3
+   b. Evaluate the right operand: Literal `4` → 4
+   c. Perform the operation: 3 * 4 = 12
+4. Perform the root operation: 5 + 12 = 17
+
+The result is 17.
+
+### Detailed Traversal
+
+1. `interpret` calls `evaluate` on the root expression
+2. `evaluate` calls `accept` on the Binary `+` node
+3. `accept` calls `visitBinaryExpr` on the interpreter
+4. `visitBinaryExpr` calls `evaluate` on the left child (Literal `5`)
+5. `evaluate` calls `accept` on the Literal `5` node
+6. `accept` calls `visitLiteralExpr` which returns 5
+7. Back in `visitBinaryExpr`, `evaluate` is called on the right child (Binary `*`)
+8. This process repeats for the `*` expression and its children
+9. Once both operands are evaluated, `visitBinaryExpr` performs the addition
+
+This demonstrates the post-order traversal, where children are fully evaluated before their parent operations are performed.

--- a/LexTree/Interpreter/Value.h
+++ b/LexTree/Interpreter/Value.h
@@ -1,0 +1,49 @@
+#pragma once
+#include <string>
+#include <variant>
+
+namespace lex
+{
+    // Forward declarations for user-defined types
+    class LexFunction;
+    class LexClass;
+    class LexInstance;
+
+
+    // Runtime value representation
+    using Value = std::variant<
+    std::monostate,  // nil
+    bool,            // boolean
+    double,          // number
+    std::string      // string
+    >;
+
+    // Helper functions for working with values
+    inline bool is_truthy(const Value& value)
+    {
+        // nil and false are falsey, everything else is truthy
+        if (std::holds_alternative<std::monostate>(value))
+            return false;
+        if (std::holds_alternative<bool>(value))
+            return std::get<bool>(value);
+        return true;
+    }
+
+    inline bool values_equal(const Value& a, const Value& b)
+    {
+        if (a.index() != b.index()) return false;
+
+        if (std::holds_alternative<std::monostate>(a)) return true;
+        if (std::holds_alternative<bool>(a))
+            return std::get<bool>(a) == std::get<bool>(b);
+        if (std::holds_alternative<double>(a))
+            return std::get<double>(a) == std::get<double>(b);
+        if (std::holds_alternative<std::string>(a))
+            return std::get<std::string>(a) == std::get<std::string>(b);
+
+        return false; // For future types
+    }
+
+    // Convert value to string for printing
+    std::string value_to_string(const Value& value);
+}

--- a/LexTree/LexTree.h
+++ b/LexTree/LexTree.h
@@ -2,12 +2,14 @@
 
 #include <string>
 #include <vector>
+#include "Interpreter/Interpreter.h"
 
 namespace lex
 {
     class LexTree {
     public:
         static bool hadError;
+        static bool hadRuntimeError;
 
         static void report(int line, const std::string &where,
                            const std::string &message);
@@ -19,5 +21,7 @@ namespace lex
         static void run(const std::string &source);
 
         static void error(int line, const std::string &message);
+
+        static void runtimeError(const RuntimeError& error);
     };
 } // namespace lex

--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@
 
 - [Lexer](LexTree/Lexer)
 - [Parser](LexTree/Parser)
+- [Interpreter](LexTree/Interpreter)


### PR DESCRIPTION
This PR adds the initial tree-walk interpreter that evaluates the expression's AST in post-order traversal and maintains the checks for runtime errors